### PR TITLE
fix flaky

### DIFF
--- a/src/test/java/com/hubspot/jinjava/lib/filter/ListFilterTest.java
+++ b/src/test/java/com/hubspot/jinjava/lib/filter/ListFilterTest.java
@@ -44,7 +44,8 @@ public class ListFilterTest {
   public void itConvertsSetsToLists() {
     Set<Integer> ints = Sets.newHashSet(1, 2, 3);
     List<?> o = (List<?>) filter.filter(ints, null);
-    assertThat(o).isEqualTo(Lists.newArrayList(1, 2, 3));
+    assertThat(o).containsOnlyElementsOf(Lists.newArrayList(1, 2, 3));
+    assertThat(o).hasSameSizeAs(Lists.newArrayList(1, 2, 3));
   }
 
   @Test


### PR DESCRIPTION
found an implementation dependent flaky test by using `mvn  edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=ListFilterTest#itConvertsSetsToLists -DnondexMode=ONE -DnondexRuns=10`. 

The test name is `itConvertsSetsToLists` which is in test class `ListFilterTest`.

The flakiness is cause by Java collection set does not preserve the order. Cast set to list and compare with the expected may fail. 

I change the test to only compare if two list contain the same element and if two list have the same size.